### PR TITLE
Fix Integrations and Flows appearance

### DIFF
--- a/main.css
+++ b/main.css
@@ -447,10 +447,19 @@ main {
 div.am-integrations {
   position: static;
   overflow: visible;
+  background: transparent !important;
 }
 div.am-integrations__grid,
 div.am-integrations__grid:first-child {
+  background: transparent !important;
   padding: 0;
+}
+div.am-integration-tile {
+  outline: none;
+  border: none;
+}
+div.am-integration-tile:hover {
+  outline: solid 4px #839CF8;
 }
 
 /* Automations page */

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -432,27 +432,7 @@ function createWidgets() {
 
     // Create Integrations Page widget.
     widgets.integrations = appmixer.ui.Integrations({
-        el: '#appmixer-integrations',
-        theme: {
-            variables: {
-                colors: {
-                    surface: 'transparent',
-                    above: '#FFFFFF'
-                }
-            },
-            ui: {
-                '#Integrations': {
-                    '#integration': {
-                        outline: 'none',
-                        border: 'none',
-                        "@hovered": {
-                            outline: 'solid 4px #839CF8',
-                            border: 'none'
-                        }
-                    }
-                }
-            }
-        }
+        el: '#appmixer-integrations'
     });
     widgets.integrations.on('integration:create', templateId => {
         widgets.wizard.close();
@@ -481,11 +461,11 @@ function createWidgets() {
             variables: {
                 colors: {
                     separator: '#6E8BD3',
+                    surfaceLow: '#3265CB',
                     surface: '#3265CB',
-                    base: '#3265CB',
                     neutral: '#FFFFFF',
-                    focus: '#FFFFFF',
-                    focusNG: '#3265CB'
+                    primary: '#FFFFFF',
+                    onPrimary: '#3265CB'
                 }
             }
         },


### PR DESCRIPTION
The appearance was broken by theme convertor changes on QA:

![image](https://github.com/clientIO/appmixer-demo-firebase-vanilla/assets/71525327/9aff55b3-62f1-4e1e-8252-cf80fc6052e4)

- Fix overriding of styles for Integrations and Flow Manager widgets

---

The demo should not use the SDK build from QA - which is used for development and testing of unreleased features.

