### PR TITLE
Fix Wizard close event handler

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -445,10 +445,9 @@ function createWidgets() {
 
     // Create Wizard Page widget.
     widgets.wizard = appmixer.ui.Wizard();
-    widgets.wizard.on('flow:start-after', () => widgets.integrations.reload());
-    widgets.wizard.on('flow:remove-after', () => {
+    widgets.wizard.on('close', ({ next }) => {
         widgets.integrations.reload();
-        widgets.wizard.close();
+        next();
     });
 
     // Create Automations Page widget.


### PR DESCRIPTION
Both "flow:start-after" and "flow:remove-after" trigger a "close" event unless overridden. To reload integrations when the Wizard closes itself and then close the Wizard, bind to the "close" event.